### PR TITLE
Make code compatible with Python 2.7 and Python >=3.6

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,18 +1,17 @@
 dependencies:
   pre:
+    # setup test env/isolation
     - mkdir -p $CIRCLE_TEST_REPORTS/flake8
-    - mkdir -p $CIRCLE_TEST_REPORTS/nosetests
-    - mkdir -p $CIRCLE_TEST_REPORTS/coverage
-
     # Python setup
     - pip install --upgrade pip
     - pip install --upgrade -r dev-requirements.txt
 
+  override:
+    # tell tox to use pyenv
+    - pyenv local 2.7.12 3.6.1
+
+
 test:
   override:
     - flake8 --exit-zero --output-file=$CIRCLE_TEST_REPORTS/flake8/report.txt scrapydatadog/
-    - >
-      nosetests -v --with-doctest --with-timer
-      --with-xunit --xunit-file=$CIRCLE_TEST_REPORTS/nosetests/unit_tests.xml
-      --with-coverage --cover-min-percentage=64 --cover-html --cover-erase --cover-package=scrapydatadog
-      --cover-html-dir=$CIRCLE_TEST_REPORTS/coverage/unit_tests
+    - tox

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,10 +1,11 @@
 -r requirements.txt
 
 coverage==4.5
+flake8==3.5.0
 ipdb==0.10.3
 mock==2.0.0
 nose==1.3.7
 nose-cov==1.6
 nose-timer==0.7.1
-flake8==3.5.0
-
+tox==3.0.0
+tox-pyenv==1.1.0

--- a/scrapydatadog/__init__.py
+++ b/scrapydatadog/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = 'Kpler Engineering',
 __title__ = 'scrapydatadog'
-__version__ = '0.2.3'
+__version__ = '0.2.4'

--- a/scrapydatadog/extension.py
+++ b/scrapydatadog/extension.py
@@ -45,6 +45,7 @@ stats api:   https://doc.scrapy.org/en/latest/topics/stats.html
 # role: scraping
 # stack: sourcing
 
+from __future__ import absolute_import
 import logging
 
 import datadog
@@ -158,7 +159,7 @@ class DatadogExtension(object):
 
         metrics = []
 
-        if 'finish_time' in job_stats.keys() and 'start_time' in job_stats.keys():
+        if 'finish_time' in list(job_stats.keys()) and 'start_time' in list(job_stats.keys()):
             elapsed_time = job_stats['finish_time'] - job_stats['start_time']
             metrics.append(collect('elapsed_time', elapsed_time.seconds))
 

--- a/scrapydatadog/extension.py
+++ b/scrapydatadog/extension.py
@@ -45,7 +45,7 @@ stats api:   https://doc.scrapy.org/en/latest/topics/stats.html
 # role: scraping
 # stack: sourcing
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 import logging
 
 import datadog

--- a/scrapydatadog/settings.py
+++ b/scrapydatadog/settings.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 import logging
 import os
 

--- a/scrapydatadog/settings.py
+++ b/scrapydatadog/settings.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
 import logging
 import os
 
 from scrapy.exceptions import NotConfigured
 from datadog.api.constants import CheckStatus
+import six
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +89,6 @@ def merge_env(settings):
     ALL_SETTINGS = MANDATORY_SETTINGS + CUSTOM_SETTINGS
 
     settings.update({
-        k: v for k, v in os.environ.iteritems()
+        k: v for k, v in six.iteritems(os.environ)
         if k in ALL_SETTINGS and k not in settings
     })

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 try:
     from setuptools import setup
 except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
 try:
     from setuptools import setup
 except ImportError:

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8; -*-
 
+from __future__ import absolute_import
 import os
 import unittest
 

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8; -*-
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 import os
 import unittest
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,28 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+# Choose your Python versions. They have to be available
+# on the system the tests are run on.
+envlist = py27, py36
+
+# Tell tox to not require a setup.py file
+skipsdist = True
+
+[testenv]
+passenv = *
+whitelist_externals = mkdir
+deps =
+  -rdev-requirements.txt
+  -rrequirements.txt
+
+commands=
+  mkdir -p {env:CIRCLE_TEST_REPORTS:}/tests/{envname}/nosetests
+  mkdir -p {env:CIRCLE_TEST_REPORTS:}/tests/{envname}/coverage
+
+  nosetests {posargs:-v --with-timer \
+  --with-xunit --xunit-file={env:CIRCLE_TEST_REPORTS:}/tests/{envname}/nosetests/unit_tests.xml \
+  --with-coverage --cover-min-percentage=64 --cover-html --cover-erase --cover-package=scrapydatadog \
+  --cover-html-dir={env:CIRCLE_TEST_REPORTS:}/tests/{envname}/coverage/unit_tests}


### PR DESCRIPTION
1- Run modernize command to turn py2 code into a six-compatible code (py27 + py36)
2- Edit result manually
3- Test code and dependencies installation with `tox` command for both python versions