### PR TITLE
fix(test): update tests using settings object

### DIFF
--- a/scrapydatadog/__init__.py
+++ b/scrapydatadog/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = 'Kpler Engineering',
 __title__ = 'scrapydatadog'
-__version__ = '0.2.6'
+__version__ = '0.2.7'

--- a/scrapydatadog/settings.py
+++ b/scrapydatadog/settings.py
@@ -54,25 +54,32 @@ DD_STATUS_MAPPING = {
 }
 
 
-def validate_conf(conf):
-    """Abort extension setup if we don't have all the required settings.
+def getbool(conf, key):
+    """Emulation of scrapy.Settings;getbool.
 
-    Example:
-        >>> validate_conf({})
-        Traceback (most recent call last):
-            ...
-        NotConfigured
-        >>> validate_conf({
-        ... 'DATADOG_API_KEY': 'xxxx',
-        ... 'DATADOG_APP_KEY': 'yyyy',
-        ... 'SCRAPY_PROJECT_ID': '123',
-        ... })
+    It allows the config to remain agnostic from Scrapy specificities. Not that
+    it brings much to the table but that's really cheap to make it so.
+
+    Examples:
+        >>> getbool({}, 'foo')
+        False
+        >>> getbool({'foo': 'no'}, 'foo')
+        False
+        >>> getbool({'foo': 'yes'}, 'foo')
+        True
+        >>> getbool({'foo': 'True'}, 'foo')
+        True
 
     """
+    return conf.get(key) in [True, 'True', 'true', 'yes', 'y']
+
+
+def validate_conf(conf):
+    """Abort extension setup if we don't have all the required settings."""
     # shortcut to disable the extension - especially useful for local
     # development that doesn't require metrics
     # if conf.get()
-    if conf.getbool('DATADOG_DISABLED'):
+    if getbool(conf, 'DATADOG_DISABLED'):
         logger.warning('extension explicitely disabled')
         raise NotConfigured
 

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -6,17 +6,19 @@ import unittest
 
 from mock import Mock
 from scrapy.exceptions import NotConfigured
+from scrapy.settings import Settings
 
 from scrapydatadog.extension import DatadogExtension
+from scrapydatadog.settings import merge_env
 
 
-class TestDatadogExtension(unittest.TestCase):
+class TestDatadogConfig(unittest.TestCase):
 
     def test_unconfigured_init(self):
         crawler = Mock()
         # don't include `DATADOG_API_KEY` and make sure it's not in the env
         os.environ.pop('DATADOG_API_KEY', None)
-        crawler.settings = {'DATADOG_APP_KEY': 'azertyuiop123456789'}
+        crawler.settings = Settings({'DATADOG_APP_KEY': 'azertyuiop123456789'})
 
         with self.assertRaises(NotConfigured):
             self.extension = DatadogExtension.from_crawler(crawler)
@@ -27,13 +29,32 @@ class TestDatadogExtension(unittest.TestCase):
         scrapy_id = '000'
 
         crawler = Mock()
-        crawler.settings = {'DATADOG_API_KEY': dd_api_key,
-                            'DATADOG_APP_KEY': dd_app_key,
-                            'SCRAPY_PROJECT_ID': scrapy_id}
+        crawler.settings = Settings({
+            'DATADOG_API_KEY': dd_api_key,
+            'DATADOG_APP_KEY': dd_app_key,
+            'SCRAPY_PROJECT_ID': scrapy_id,
+        })
 
-        raised = False
+        raised = None
         try:
             DatadogExtension.from_crawler(crawler)
-        except:
-            raised = True
-        self.assertFalse(raised, 'Exception raised')
+        except Exception as e:  # noqa
+            raised = e
+        self.assertIsNone(raised, 'Exception raised: {}'.format(raised))
+
+    def test_merging_environ_in_settings(self):
+        # add something that shouldn't be read
+        os.environ['HELLO'] = 'world'
+        # add a custom setting
+        os.environ['DATADOG_HOST_NAME'] = 'localhost'
+        # and a mandatory setting
+        os.environ['DATADOG_API_KEY'] = 'xxxxx'
+        # and a normal init + something arbitrary that should stay there
+        settings = Settings({'FOO': 'bar'})
+
+        merge_env(settings)
+
+        self.assertEqual(settings['FOO'], 'bar')
+        self.assertEqual(settings['DATADOG_HOST_NAME'], 'localhost')
+        self.assertEqual(settings['DATADOG_API_KEY'], 'xxxxx')
+        self.assertIsNone(settings.get('HELLO'))


### PR DESCRIPTION
The new setting introduced to disable the extension was using a Scrapy setting method not available with dicts. This PR fixes this.